### PR TITLE
Patch adventure mode bug that occurs on map change

### DIFF
--- a/src/io/github/feydk/vertigo/VertigoGame.java
+++ b/src/io/github/feydk/vertigo/VertigoGame.java
@@ -210,10 +210,10 @@ class VertigoGame
     {
         if(player != null)
         {
-            if(player.getGameMode() != GameMode.ADVENTURE) {
+            /*if(player.getGameMode() != GameMode.ADVENTURE) {
                 player.setGameMode(GameMode.ADVENTURE);
             }
-
+            */
             scoreboard.removePlayer(player);
             players.remove(player);
         }


### PR DESCRIPTION
leave() runs after join(), which meant players were starting the game in adventure mode rather than creative mode when the maps changed. 
Lazy fix for this is just removing setting the players to adventure mode from leave(), since it doesn't really need to do that anymore anyways.